### PR TITLE
more action alert screen fixes

### DIFF
--- a/BernieApp.UWP/Controls/AlertPresenter.xaml
+++ b/BernieApp.UWP/Controls/AlertPresenter.xaml
@@ -10,16 +10,25 @@
 >
 
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" SizeChanged="Grid_SizeChanged">
-                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
-                              HorizontalAlignment="Center"  VerticalAlignment="Top"
-                              x:Name="scrollViewer">
-                    <WebView VerticalAlignment ="Top" HorizontalAlignment="Center" MaxWidth="500" x:Name="webView" 
-                             NavigationCompleted="webView_NavigationCompleted" PermissionRequested="webView_PermissionRequested" 
-                             UnsafeContentWarningDisplaying="webView_UnsafeContentWarningDisplaying" UnviewableContentIdentified="webView_UnviewableContentIdentified"/>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="40"/>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-                <!-- Eventually set the Webview's DefaultBackgroundColor="#FFE6E6E6", but can't mess with facebook posts-->
-                </ScrollViewer>
-            <ProgressRing x:Name="ProgressRing" Foreground="#FF147FD7" IsActive="True" Width="100" Height="100"/>
+        <TextBlock Grid.Row="0" HorizontalAlignment="Center" Text="{Binding Title}" Style="{ThemeResource SubtitleTextBlockStyle}"/>
+        <TextBlock Grid.Row="1" HorizontalAlignment="Center" Text="{Binding ShortDescription}" Style="{ThemeResource BaseTextBlockStyle}"/>
+
+        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
+                            HorizontalAlignment="Center"  VerticalAlignment="Top"
+                            x:Name="scrollViewer">
+            <WebView VerticalAlignment ="Top" HorizontalAlignment="Center" MaxWidth="500" x:Name="webView" DefaultBackgroundColor="Transparent"
+                        NavigationCompleted="webView_NavigationCompleted" PermissionRequested="webView_PermissionRequested" 
+                        UnsafeContentWarningDisplaying="webView_UnsafeContentWarningDisplaying" UnviewableContentIdentified="webView_UnviewableContentIdentified"/>
+        </ScrollViewer>
+        
+        <ProgressRing Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="ProgressRing" Foreground="#FF147FD7" 
+                      IsActive="True" Width="100" Height="100"/>
     </Grid>
 
 </UserControl>

--- a/BernieApp.UWP/Controls/AlertPresenter.xaml.cs
+++ b/BernieApp.UWP/Controls/AlertPresenter.xaml.cs
@@ -3,22 +3,9 @@ using BernieApp.UWP.Messages;
 using BernieApp.UWP.ViewModels;
 using GalaSoft.MvvmLight.Messaging;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Threading;
-using System.Threading.Tasks;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 
 // The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
 


### PR DESCRIPTION
1) adding title and shortdescription to the top of alert template. shortdescription is empty most of the time though.
2) also setting background color of alerts to transparent - it does make fb-post (some not all) look weird, but a step in the right direction (also the android app has the same issue so we are not alone)
