### PR TITLE
mobile news feed fixes

### DIFF
--- a/BernieApp.UWP/Controls/DeviceFamily-Mobile/NewsPresenter.xaml
+++ b/BernieApp.UWP/Controls/DeviceFamily-Mobile/NewsPresenter.xaml
@@ -69,7 +69,14 @@
                       ItemsSource="{Binding Items}" HorizontalAlignment="Center" Margin="0"
                       SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
                       ScrollViewer.VerticalScrollBarVisibility="Hidden"
-                      SizeChanged="Newsfeed_SizeChanged">
+                      SizeChanged="Newsfeed_SizeChanged"
+                      Loading="Newsfeed_Loading" Loaded="Newsfeed_Loaded">
+            <GridView.ItemContainerStyle>
+                <Style TargetType="GridViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                </Style>
+            </GridView.ItemContainerStyle>
+            
             <Interactivity:Interaction.Behaviors>
                 <Core:EventTriggerBehavior EventName="SelectionChanged">
                     <Core:CallMethodAction MethodName="GoToDetailsPage" TargetObject="{Binding}"/>


### PR DESCRIPTION
1) progress ring should hide when done loading
2) fixing mobile news feed widths by setting
horizontalcontentalignment=stretch with style to targettype=gridviewitem
(investigate via live visual tree editor)
